### PR TITLE
Got it up and running on my system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ set(PROJECT_SOURCES
         widget.ui
 )
 
+add_compile_options(-Wall -Wextra -Werror)
+
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
     qt_add_executable(Nicks_QtChart
         MANUAL_FINALIZATION

--- a/widget.cpp
+++ b/widget.cpp
@@ -1,6 +1,7 @@
 #include "widget.h"
 #include "ui_widget.h"
 
+#include <QAction>
 #include <QDebug>
 #include <QFileDialog>
 #include <QGridLayout>
@@ -27,7 +28,14 @@ Widget::Widget(QWidget *parent)
     ui->setupUi(this);
     this->resize(300, 500);
 
-
+    auto action = new QAction{"Dummy Plot", this};
+    action->setShortcut(QKeySequence{Qt::CTRL + Qt::Key_D});
+    addAction(action);
+    connect(action, &QAction::triggered, this, [this]{
+        auto chartView = new QChartView(createLineChart());
+        ui->horizontalLayout->addWidget(chartView, 1);
+        m_charts << chartView;
+    });
 
 
     QString thefilename;

--- a/widget.cpp
+++ b/widget.cpp
@@ -18,11 +18,11 @@
 
 Widget::Widget(QWidget *parent)
     : QWidget(parent),
+      ui(new Ui::Widget),
       m_listCount(3),
       m_valueMax(10),
       m_valueCount(7),
-      m_dataTable(generateRandomData(m_listCount, m_valueMax, m_valueCount)),
-      ui(new Ui::Widget)
+      m_dataTable(generateRandomData(m_listCount, m_valueMax, m_valueCount))
 {
     ui->setupUi(this);
     this->resize(300, 500);

--- a/widget.cpp
+++ b/widget.cpp
@@ -1,16 +1,20 @@
 #include "widget.h"
-#include "./ui_widget.h"
+#include "ui_widget.h"
 
+#include <QDebug>
+#include <QFileDialog>
+#include <QGridLayout>
+#include <QMessageBox>
+#include <QRandomGenerator>
+#include <QRegularExpression>
+#include <QTextStream>
 #include <QWidget>
-#include <QtCharts/QChartGlobal>
+
+#include <QtCharts/QChart>
 #include <QtCharts/QChartView>
 #include <QtCharts/QLegend>
-#include <QtWidgets/QGridLayout>
-#include <QLineSeries>
-#include <QRandomGenerator>
-#include <QFileDialog>
-#include <QRegularExpression>
-#include <QMessageBox>
+#include <QtCharts/QLineSeries>
+
 
 Widget::Widget(QWidget *parent)
     : QWidget(parent),

--- a/widget.h
+++ b/widget.h
@@ -40,13 +40,15 @@ private slots:
     void on_pushButton_3_clicked();
 
 private:
-    Ui::Widget *ui;
     DataTable generateRandomData(int listCount, int valueMax, int valueCount) const;
     QChart *createLineChart() const;
-    DataTable m_dataTable;
+
+    Ui::Widget *ui;
+
     int m_listCount;
     int m_valueMax;
     int m_valueCount;
+    DataTable m_dataTable;
     QList<QChartView *> m_charts;
     QString thefilename;
 };

--- a/widget.h
+++ b/widget.h
@@ -9,16 +9,18 @@ QT_BEGIN_NAMESPACE
 namespace Ui { class Widget; }
 QT_END_NAMESPACE
 
-QT_BEGIN_NAMESPACE
+QT_CHARTS_BEGIN_NAMESPACE
 class QChartView;
 class QChart;
-QT_END_NAMESPACE
+QT_CHARTS_END_NAMESPACE
+
 
 typedef QPair<QPointF, QString> Data;
 typedef QList<Data> DataList;
 typedef QList<DataList> DataTable;
 
 QT_USE_NAMESPACE
+QT_CHARTS_USE_NAMESPACE
 
 class Widget : public QWidget
 {


### PR DESCRIPTION
Had to do a few things to make it work on my machine.

BTW, if you're using QtCreator, pay attention to the yellow warnings it creates via "clang-tidy".

In particular, there are some memory leaks in the code.

The first thing I'll suggest you do is only declare variables right before you need them, i.e., limit their *scope*.
Declaring everything up front is an ancient C practice that has never been needed in C++
and hasn't been needed in C since C99, but GCC allowed it long before that.